### PR TITLE
docs: rename method to actual

### DIFF
--- a/keeper/ext/resource/README.md
+++ b/keeper/ext/resource/README.md
@@ -13,7 +13,7 @@ Resources
 /* Paste code from ./dist/perf-keeper.js */
 /* Paste code from ./dist/perf-keeper.ext.resource.js */
 
-perfKeeperExtResource.resourceTimings(perfKeeper.system);
+perfKeeperExtResource.resourceStats(perfKeeper.system);
 </script>
 ```
 


### PR DESCRIPTION
`resourceStats` instead of `resourceTimings`